### PR TITLE
updated from http cdn to https cdn

### DIFF
--- a/demos/leaflet-corridor/index.html
+++ b/demos/leaflet-corridor/index.html
@@ -4,8 +4,8 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>leaflet-corridor example</title>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" media="screen"/>
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.css" media="screen"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.js"></script>
     <script src="./leaflet-corridor.js" type="text/javascript"></script>
     <script src="./line_coords.js" type="text/javascript"></script>
     <style> 


### PR DESCRIPTION
Unable to open the hosted demo since the demo is served over https and the cdn's are http.